### PR TITLE
Update README.md fix hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@
 * Initial rerelease
 
 ## Source Code
-* Module [GitHub](https://github.com/therealahrion/Audio-Modification-Library)
+* Module [GitHub](https://github.com/therealahrion/Xposed-Framework-Unity)


### PR DESCRIPTION
Fix hyperlink for module source code.  This hyperlink pops up in Magisk Manager, which is how I noticed the error.